### PR TITLE
TP-26791 Python 3 upgrade: py-wkhtmltox upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ RUN apt-get update && apt-get install -y \
     python-pip \
     python-dev
 
+RUN curl --silent https://www.python.org/ftp/python/3.4.10/Python-3.4.10.tgz -o Python-3.4.10.tgz
+RUN tar -xf Python-3.4.10.tgz
+RUN cd Python-3.4.10 && ./configure --enable-optimizations --enable-shared --with-ensurepip=install && make -j2 install
+
 RUN curl --silent -q https://s3-eu-west-1.amazonaws.com/scurri-requirement-debs/wkhtmltox-0.12.2.1_linux-trusty-amd64.deb -o wkhtmltox-0.12.2.1_linux-trusty-amd64.deb
 RUN dpkg -i wkhtmltox-0.12.2.1_linux-trusty-amd64.deb && ldconfig
 
@@ -34,5 +38,4 @@ COPY ./*.py ./*.pyx ./*.toml ./*.cfg ./*.c LICENSE ./
 COPY tests/*.py tests/simple.* tests/*.html tests/
 COPY pip-cache pip-cache
 COPY requirements/* requirements/
-RUN pip install --user --no-index --find-links=file:///app/pip-cache -qr requirements/build.txt
-RUN pip install --user --no-index --find-links=file:///app/pip-cache -qU tox==3.14.0
+RUN pip3 install -Uq -r requirements/build.txt

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ see: [page settings](http://wkhtmltopdf.org/libwkhtmltox/pagesettings.html)
 pip install -U -r requirements/build.txt
 pip install -e .
 ```
-`pip` can create `wkhtmltox.so` and the file conflicts with `tox` (run locally)
-unless it's deleted. 
+`pip` can create `wkhtmltox.so` or `wkhtmltox.cpython-34m.so` and the file conflicts
+with `tox` (run locally) unless it's deleted. 
 But don't be surprise when `tox` will fail. It is due to dynamic nature of HTML,
 your local system can render HTML slightly different so content of converted
 PDF will be ok, but not (byte by byte) 100% exactly the same all the time.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,5 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: bash -c 'python -m tox -q'
+    command: bash -c 'tox -q'
     container_name: py-wkhtmltox-tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,12 +19,14 @@ exclude =
     tests*
 
 [tox:tox]
-envlist = py27
+envlist = py34,py27
 
 [testenv]
-install_command = pip install -q --no-index --find-links=file:///app/pip-cache {opts} {packages}
 commands = pytest -q tests
 deps =
     pytest==4.6.11
     Pillow==5.4.1
     PyPDF2==1.25.1
+
+[testenv:py27]
+install_command = pip install -q --no-index --find-links=file:///app/pip-cache {opts} {packages}

--- a/wkhtmltox.c
+++ b/wkhtmltox.c
@@ -448,7 +448,7 @@ static char __pyx_k____main__[] = "__main__";
 static char __pyx_k____test__[] = "__test__";
 static char __pyx_k__add_page[] = "add_page";
 static char __pyx_k__settings[] = "settings";
-static char __pyx_k__iteritems[] = "iteritems";
+static char __pyx_k__items[] = "items";
 static char __pyx_k____getattr__[] = "__getattr__";
 static char __pyx_k___c_global_settings[] = "_c_global_settings";
 static PyObject *__pyx_n_s_1;
@@ -462,7 +462,7 @@ static PyObject *__pyx_n_s___pdf;
 static PyObject *__pyx_n_s__add_page;
 static PyObject *__pyx_n_s__convert;
 static PyObject *__pyx_n_s__getattr;
-static PyObject *__pyx_n_s__iteritems;
+static PyObject *__pyx_n_s__items;
 static PyObject *__pyx_n_s__name;
 static PyObject *__pyx_n_s__pages;
 static PyObject *__pyx_n_s__self;
@@ -735,7 +735,7 @@ static PyObject *__pyx_pf_9wkhtmltox_4_Pdf_convert(PyObject *__pyx_v_self, PyObj
  * 
  *         for page in pages:             # <<<<<<<<<<<<<<
  *             os = wkhtmltopdf_create_object_settings()
- *             for k, v in page.iteritems():
+ *             for k, v in page.items():
  */
   if (PyList_CheckExact(__pyx_v_pages) || PyTuple_CheckExact(__pyx_v_pages)) {
     __pyx_t_1 = 0; __pyx_t_3 = __pyx_v_pages; __Pyx_INCREF(__pyx_t_3);
@@ -766,7 +766,7 @@ static PyObject *__pyx_pf_9wkhtmltox_4_Pdf_convert(PyObject *__pyx_v_self, PyObj
  * 
  *         for page in pages:
  *             os = wkhtmltopdf_create_object_settings()             # <<<<<<<<<<<<<<
- *             for k, v in page.iteritems():
+ *             for k, v in page.items():
  *                 wkhtmltopdf_set_object_setting(os, k, v)
  */
     __pyx_v_os = wkhtmltopdf_create_object_settings();
@@ -774,11 +774,11 @@ static PyObject *__pyx_pf_9wkhtmltox_4_Pdf_convert(PyObject *__pyx_v_self, PyObj
     /* "/Users/mreiferson/dev/git/py-wkhtmltox/wkhtmltox.pyx":91
  *         for page in pages:
  *             os = wkhtmltopdf_create_object_settings()
- *             for k, v in page.iteritems():             # <<<<<<<<<<<<<<
+ *             for k, v in page.items():             # <<<<<<<<<<<<<<
  *                 wkhtmltopdf_set_object_setting(os, k, v)
  *             wkhtmltopdf_add_object(c, os, NULL)
  */
-    __pyx_t_4 = PyObject_GetAttr(__pyx_v_page, __pyx_n_s__iteritems); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 91; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_4 = PyObject_GetAttr(__pyx_v_page, __pyx_n_s__items); if (unlikely(!__pyx_t_4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 91; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_4);
     __pyx_t_6 = PyObject_Call(__pyx_t_4, ((PyObject *)__pyx_empty_tuple), NULL); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 91; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_6);
@@ -836,7 +836,7 @@ static PyObject *__pyx_pf_9wkhtmltox_4_Pdf_convert(PyObject *__pyx_v_self, PyObj
 
       /* "/Users/mreiferson/dev/git/py-wkhtmltox/wkhtmltox.pyx":92
  *             os = wkhtmltopdf_create_object_settings()
- *             for k, v in page.iteritems():
+ *             for k, v in page.items():
  *                 wkhtmltopdf_set_object_setting(os, k, v)             # <<<<<<<<<<<<<<
  *             wkhtmltopdf_add_object(c, os, NULL)
  * 
@@ -848,7 +848,7 @@ static PyObject *__pyx_pf_9wkhtmltox_4_Pdf_convert(PyObject *__pyx_v_self, PyObj
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
     /* "/Users/mreiferson/dev/git/py-wkhtmltox/wkhtmltox.pyx":93
- *             for k, v in page.iteritems():
+ *             for k, v in page.items():
  *                 wkhtmltopdf_set_object_setting(os, k, v)
  *             wkhtmltopdf_add_object(c, os, NULL)             # <<<<<<<<<<<<<<
  * 
@@ -1949,7 +1949,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s__add_page, __pyx_k__add_page, sizeof(__pyx_k__add_page), 0, 0, 1, 1},
   {&__pyx_n_s__convert, __pyx_k__convert, sizeof(__pyx_k__convert), 0, 0, 1, 1},
   {&__pyx_n_s__getattr, __pyx_k__getattr, sizeof(__pyx_k__getattr), 0, 0, 1, 1},
-  {&__pyx_n_s__iteritems, __pyx_k__iteritems, sizeof(__pyx_k__iteritems), 0, 0, 1, 1},
+  {&__pyx_n_s__items, __pyx_k__items, sizeof(__pyx_k__items), 0, 0, 1, 1},
   {&__pyx_n_s__name, __pyx_k__name, sizeof(__pyx_k__name), 0, 0, 1, 1},
   {&__pyx_n_s__pages, __pyx_k__pages, sizeof(__pyx_k__pages), 0, 0, 1, 1},
   {&__pyx_n_s__self, __pyx_k__self, sizeof(__pyx_k__self), 0, 0, 1, 1},

--- a/wkhtmltox.pyx
+++ b/wkhtmltox.pyx
@@ -88,7 +88,7 @@ cdef class _Pdf:
         
         for page in pages:
             os = wkhtmltopdf_create_object_settings()
-            for k, v in page.iteritems():
+            for k, v in page.items():
                 wkhtmltopdf_set_object_setting(os, k, v)
             wkhtmltopdf_add_object(c, os, NULL)
         


### PR DESCRIPTION
Python 3 upgrade: py-wkhtmltox upgrade
https://scurri.tpondemand.com/entity/26791-python-3-upgrade-py-wkhtmltox-upgrade

As a Scurri developer, I would like to upgrade the py-wkhtmltox library to support Python 2.7 and Python 3.4+.

The library can be found here:
https://github.com/Scurri/py-wkhtmltox

Tests using `tox` must be implemented to ensure that the upgraded library is supported by both, Python 2.7 and 3.4+.

We must also bump the version so we can later update Scurri requirements.

**Acceptance Criteria**
* The library is upgraded
* Proper tests are implemented
* The version is bumped

**Goal**
* Make the library Python 2 and 3 compatible

**Checks**
 - [x] Acceptance Criteria Satisfied
 - [x] Code changes are covered by test suite
 - [x] Pull request is properly formatted
